### PR TITLE
Macでも動くようにする

### DIFF
--- a/resources/shader/SpriteV3.frag
+++ b/resources/shader/SpriteV3.frag
@@ -1,0 +1,12 @@
+#version 330
+
+in vec2 fragTexCoord;
+
+uniform sampler2D uTexture;
+
+out vec4 outColor;
+
+void main()
+{
+    outColor = texture(uTexture, fragTexCoord);
+}

--- a/resources/shader/SpriteV3.vert
+++ b/resources/shader/SpriteV3.vert
@@ -1,0 +1,24 @@
+#version 330
+
+uniform vec2 uWindowSize;
+uniform vec2 uTextureSize;
+uniform vec2 uTexturePosition;
+uniform float uTextureScale;
+
+layout(location = 0) in vec3 inPosition;
+layout(location = 1) in vec2 inTexCoord;
+
+out vec2 fragTexCoord;
+
+void main()
+{
+    vec2 halfWindow = uWindowSize * 0.5;
+    float positionX = (uTexturePosition.x - halfWindow.x) / halfWindow.x;
+    float positionY = (uTexturePosition.y - halfWindow.y) / halfWindow.y * -1.0;
+    vec2 diff = (uTextureSize / uWindowSize) * 0.5 * uTextureScale;
+
+    vec2 finalPosition = vec2(positionX, positionY) + inPosition.xy * diff;
+
+    gl_Position = vec4(finalPosition, inPosition.z, 1.0);
+    fragTexCoord = inTexCoord;
+}

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -22,6 +22,14 @@
 int WINDOW_WIDTH  = 1024;
 int WINDOW_HEIGHT = 768;
 
+#ifdef __EMSCRIPTEN__
+static const std::string SPRITE_SHADER_VERT = "resources/shader/Sprite.vert";
+static const std::string SPRITE_SHADER_FRAG = "resources/shader/Sprite.frag";
+#else
+static const std::string SPRITE_SHADER_VERT = "resources/shader/SpriteV3.vert";
+static const std::string SPRITE_SHADER_FRAG = "resources/shader/SpriteV3.frag";
+#endif
+
 bool running = true;
 SDL_Window* window;
 SDL_GLContext context;
@@ -511,7 +519,7 @@ int main(int argc, char* argv[])
 
     glGetError();  // On some platforms, GLEW will emit a benign error code, so clear it
 
-    if (!loadShaders("resources/shader/Sprite.vert", "resources/shader/Sprite.frag"))
+    if (!loadShaders(SPRITE_SHADER_VERT, SPRITE_SHADER_FRAG))
     {
         SDL_Log("Failed to load shaders");
         return EXIT_FAILURE;
@@ -547,7 +555,7 @@ int main(int argc, char* argv[])
 
     playMusic();
 
-    // Main Loop
+// Main Loop
 #ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(mainloop, 0, 1);
 #else


### PR DESCRIPTION
## 概要
Macでも動くようにする

## 参考URL
- [PC Watch - Apple、macOS/iOSで「OpenGL/CL」の利用を“非推奨”に](https://pc.watch.impress.co.jp/docs/news/1125772.html)

あと、Emscripten + vcpkgでエラーが発生するので、Emscriptenの環境変数を追加しておく。
`export EMSCRIPTEN_ROOT="$HOMEBREW_PREFIX/opt/emscripten/libexec"`